### PR TITLE
fixing typo in console

### DIFF
--- a/interwebz/static/js/cli.js
+++ b/interwebz/static/js/cli.js
@@ -219,7 +219,7 @@ function formatReply(reply, indent = '') {
   if (type === 'string') {
     return `"${reply}"`;
   } else if (type === 'number') {
-    return `(interger) ${reply}`;
+    return `(integer) ${reply}`;
   } else if (Array.isArray(reply)) {
     if (reply.length === 0) {
       return '(empty array)';


### PR DESCRIPTION
A slight typo in console comes right through on the redis IO home page :)

![image](https://user-images.githubusercontent.com/42971704/160001077-1a697b92-3a76-4dcd-a3bb-41283e13dda8.png)
