### PR TITLE
fixing moveable key issue.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       context: .
     ports:
       - 5000:5000
+    depends_on:
+      - redis-unstable
 
   flask-nginx:
     build:


### PR DESCRIPTION
@itamarhaber There's an issue with how command-key mapping works in the case where the command is a 'moveablekey' command, this causes some of the command pages to fail weirdly. See redis/redis-doc#1936. Unfortunately, the solution here is to use the COMMAND GETKEYS command, which involves another round trip to redis, still pretty zippy.

FYI @nermiller