### PR TITLE
fixing issue with lm/zm pop

### DIFF
--- a/interwebz/redis.py
+++ b/interwebz/redis.py
@@ -258,7 +258,7 @@ class NameSpacedRedis(Redis):
             rep = self._strip_id_from_keys(session, rep)
         elif cmd_name == 'scan':
             rep[1] = self._strip_id_from_keys(session, rep[1])
-        elif cmd_name in ['lmpop','zmpop'] and len(rep) == 2:
+        elif cmd_name in ['lmpop','zmpop'] and rep is not None and len(rep) == 2:
             rep[0] = self._strip_id_from_keys(session, [rep[0]])[0]
 
         return rep


### PR DESCRIPTION
There's a tiny issue with lm/zm pop where if the result is empty clinterwebz tries to run a `len` on a `None` which is illegal, adding extra bit to check the none-case