### PR TITLE
Fix DUMP command reply

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ install_requires =
     flask >= 2.0.2
     flask-cors >= 3.0.10
     gunicorn >= 20.1.0
-    redis >= 4.1.0
+    redis >= 4.4.0
 
 [build-system]
 requires = 


### PR DESCRIPTION
## Description
The DUMP command returns binary data or '(nil)'.
When redis-py process the response, it tries to decode it to UTF-8 which cases a python exception.

The DUMP command should not be decoded for this reason, so before sending it to redis-py we add the `NEVER_DECODE` option. Now when we get it back we are getting a byte array that looks similar to this: `b'"\x00\xc0\x0c\n\x00<*\xf8Q\\\x04\xbc\xd5"'`. In order to look like redis-cli we trim it so it will look like this: `"\x00\xc0\x0c\n\x00<*\xf8Q\\\x04\xbc\xd5"`.

Also update redis-py minimum version to 4.4.0 which contains a fix that let us use `NEVER_DECODE`.

## Testing done
Tested locally
![image](https://user-images.githubusercontent.com/7628418/206222658-3d3c1c58-4e9f-421b-afa4-48e7c325e18e.png)
